### PR TITLE
添加拼音分词过滤器

### DIFF
--- a/src/main/java/com/hankcs/lucene/HanLPPinyinConverter.java
+++ b/src/main/java/com/hankcs/lucene/HanLPPinyinConverter.java
@@ -1,0 +1,48 @@
+package com.hankcs.lucene;
+
+import com.hankcs.hanlp.dictionary.py.Pinyin;
+
+import java.util.List;
+
+/**
+ * 拼音字符串
+ */
+public interface HanLPPinyinConverter {
+    CharSequence convert(String text, List<Pinyin> pinyin);
+
+    /**
+     * 全拼，HanLP.convertToPinyinString
+     */
+    class ToPinyinString implements HanLPPinyinConverter {
+        private StringBuilder buffer = new StringBuilder(32);
+
+        @Override
+        public CharSequence convert(String text, List<Pinyin> pinyin) {
+            buffer.setLength(0);
+            for (Pinyin p : pinyin) {
+                if (p != Pinyin.none5) {
+                    buffer.append(p.getPinyinWithoutTone());
+                }
+            }
+            return buffer;
+        }
+    }
+
+    /**
+     * 首字母，HanLP.convertToPinyinFirstCharString
+     */
+    class ToPinyinFirstCharString implements HanLPPinyinConverter {
+        private StringBuilder buffer = new StringBuilder(32);
+
+        @Override
+        public CharSequence convert(String text, List<Pinyin> pinyin) {
+            buffer.setLength(0);
+            for (Pinyin p : pinyin) {
+                if (p != Pinyin.none5) {
+                    buffer.append(p.getFirstChar());
+                }
+            }
+            return buffer;
+        }
+    }
+}

--- a/src/main/java/com/hankcs/lucene/HanLPPinyinTokenFilter.java
+++ b/src/main/java/com/hankcs/lucene/HanLPPinyinTokenFilter.java
@@ -19,7 +19,7 @@ public final class HanLPPinyinTokenFilter extends TokenFilter {
     // 当前词
     private final CharTermAttribute charTermAttribute = addAttribute(CharTermAttribute.class);
     // 是否保留原词
-    private final boolean reserve;
+    private final boolean original;
     // 拼音转换器
     private final Collection<HanLPPinyinConverter> converters;
     // 待输出拼音队列
@@ -36,9 +36,9 @@ public final class HanLPPinyinTokenFilter extends TokenFilter {
         this(input, true, Arrays.asList(converters));
     }
 
-    public HanLPPinyinTokenFilter(TokenStream input, boolean reserve, Collection<HanLPPinyinConverter> converters) {
+    public HanLPPinyinTokenFilter(TokenStream input, boolean original, Collection<HanLPPinyinConverter> converters) {
         super(input);
-        this.reserve = reserve;
+        this.original = original;
         this.converters = converters;
         this.queue = new ArrayDeque<>(converters.size());
     }
@@ -61,7 +61,7 @@ public final class HanLPPinyinTokenFilter extends TokenFilter {
                         queue.offer(pinyinTerm);
                     }
                 }
-                if (reserve) {
+                if (original) {
                     return true;
                 }
             } else {

--- a/src/main/java/com/hankcs/lucene/HanLPPinyinTokenFilter.java
+++ b/src/main/java/com/hankcs/lucene/HanLPPinyinTokenFilter.java
@@ -1,0 +1,72 @@
+package com.hankcs.lucene;
+
+import com.hankcs.hanlp.dictionary.py.Pinyin;
+import com.hankcs.hanlp.dictionary.py.PinyinDictionary;
+import org.apache.lucene.analysis.TokenFilter;
+import org.apache.lucene.analysis.TokenStream;
+import org.apache.lucene.analysis.tokenattributes.CharTermAttribute;
+import org.apache.lucene.analysis.tokenattributes.TypeAttribute;
+
+import java.io.IOException;
+import java.util.*;
+
+/**
+ * 拼音TokenFilter
+ */
+public final class HanLPPinyinTokenFilter extends TokenFilter {
+    // 词性
+    private final TypeAttribute typeAttribute = addAttribute(TypeAttribute.class);
+    // 当前词
+    private final CharTermAttribute charTermAttribute = addAttribute(CharTermAttribute.class);
+    // 是否保留原词
+    private final boolean reserve;
+    // 拼音转换器
+    private final Collection<HanLPPinyinConverter> converters;
+    // 待输出拼音队列
+    private final Queue<CharSequence> queue;
+
+    public HanLPPinyinTokenFilter(TokenStream input) {
+        // 默认全拼加首字母
+        this(input,
+                new HanLPPinyinConverter.ToPinyinString(),
+                new HanLPPinyinConverter.ToPinyinFirstCharString());
+    }
+
+    public HanLPPinyinTokenFilter(TokenStream input, HanLPPinyinConverter... converters) {
+        this(input, true, Arrays.asList(converters));
+    }
+
+    public HanLPPinyinTokenFilter(TokenStream input, boolean reserve, Collection<HanLPPinyinConverter> converters) {
+        super(input);
+        this.reserve = reserve;
+        this.converters = converters;
+        this.queue = new ArrayDeque<>(converters.size());
+    }
+
+    @Override
+    public boolean incrementToken() throws IOException {
+        while (true) {
+            CharSequence term = queue.poll();
+            if (term != null) {
+                typeAttribute.setType("pinyin");
+                charTermAttribute.setEmpty().append(term);
+                return true;
+            }
+            if (input.incrementToken()) {
+                String text = charTermAttribute.toString();
+                List<Pinyin> pinyin = PinyinDictionary.convertToPinyin(text);
+                for (HanLPPinyinConverter converter : converters) {
+                    CharSequence pinyinTerm = converter.convert(text, pinyin);
+                    if (pinyinTerm != null && pinyinTerm.length() > 0) {
+                        queue.offer(pinyinTerm);
+                    }
+                }
+                if (reserve) {
+                    return true;
+                }
+            } else {
+                return false;
+            }
+        }
+    }
+}

--- a/src/main/java/com/hankcs/lucene/HanLPPinyinTokenFilterFactory.java
+++ b/src/main/java/com/hankcs/lucene/HanLPPinyinTokenFilterFactory.java
@@ -17,7 +17,7 @@ public class HanLPPinyinTokenFilterFactory extends TokenFilterFactory {
      *
      * @param args 通过这个Map保存xml中的配置项
      */
-    protected HanLPPinyinTokenFilterFactory(Map<String, String> args) {
+    public HanLPPinyinTokenFilterFactory(Map<String, String> args) {
         super(args);
         original = getBoolean(args, "original", true);
         pinyin = getBoolean(args, "pinyin", true);

--- a/src/main/java/com/hankcs/lucene/HanLPPinyinTokenFilterFactory.java
+++ b/src/main/java/com/hankcs/lucene/HanLPPinyinTokenFilterFactory.java
@@ -1,0 +1,38 @@
+package com.hankcs.lucene;
+
+import org.apache.lucene.analysis.TokenStream;
+import org.apache.lucene.analysis.util.TokenFilterFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+public class HanLPPinyinTokenFilterFactory extends TokenFilterFactory {
+    private boolean original;
+    private boolean pinyin;
+    private boolean pinyinFirstChar;
+
+    /**
+     * 初始化工厂类
+     *
+     * @param args 通过这个Map保存xml中的配置项
+     */
+    protected HanLPPinyinTokenFilterFactory(Map<String, String> args) {
+        super(args);
+        original = getBoolean(args, "original", true);
+        pinyin = getBoolean(args, "pinyin", true);
+        pinyinFirstChar = getBoolean(args, "pinyinFirstChar", true);
+    }
+
+    @Override
+    public TokenStream create(TokenStream input) {
+        List<HanLPPinyinConverter> converters = new ArrayList<>();
+        if (pinyin) {
+            converters.add(new HanLPPinyinConverter.ToPinyinString());
+        }
+        if (pinyinFirstChar) {
+            converters.add(new HanLPPinyinConverter.ToPinyinFirstCharString());
+        }
+        return new HanLPPinyinTokenFilter(input, original, converters);
+    }
+}

--- a/src/test/java/com/hankcs/lucene/HanLPTokenizerTest.java
+++ b/src/test/java/com/hankcs/lucene/HanLPTokenizerTest.java
@@ -10,6 +10,8 @@ import org.apache.lucene.analysis.tokenattributes.PositionIncrementAttribute;
 import org.apache.lucene.analysis.tokenattributes.TypeAttribute;
 
 import java.io.StringReader;
+import java.util.HashMap;
+import java.util.Map;
 
 public class HanLPTokenizerTest extends TestCase
 {
@@ -60,7 +62,12 @@ public class HanLPTokenizerTest extends TestCase
 
     public void testPinyinTokenFilter() throws Exception
     {
-        TokenStream tokenStream = new HanLPPinyinTokenFilter(tokenizer);
+        Map<String, String> args = new HashMap<>();
+        args.put("original", "true");
+        args.put("pinyin", "false");
+        args.put("pinyinFirstChar", "true");
+        HanLPPinyinTokenFilterFactory factory = new HanLPPinyinTokenFilterFactory(args);
+        TokenStream tokenStream = factory.create(tokenizer);
         while (tokenStream.incrementToken())
         {
             CharTermAttribute attribute = tokenizer.getAttribute(CharTermAttribute.class);

--- a/src/test/java/com/hankcs/lucene/HanLPTokenizerTest.java
+++ b/src/test/java/com/hankcs/lucene/HanLPTokenizerTest.java
@@ -1,9 +1,8 @@
 package com.hankcs.lucene;
 
 import com.hankcs.hanlp.HanLP;
-import com.hankcs.hanlp.seg.CRF.CRFSegment;
-import com.hankcs.hanlp.tokenizer.TraditionalChineseTokenizer;
 import junit.framework.TestCase;
+import org.apache.lucene.analysis.TokenStream;
 import org.apache.lucene.analysis.Tokenizer;
 import org.apache.lucene.analysis.tokenattributes.CharTermAttribute;
 import org.apache.lucene.analysis.tokenattributes.OffsetAttribute;
@@ -56,6 +55,22 @@ public class HanLPTokenizerTest extends TestCase
             tokenizer.reset();
             testIncrementToken();
             tokenizer.close();
+        }
+    }
+
+    public void testPinyinTokenFilter() throws Exception
+    {
+        TokenStream tokenStream = new HanLPPinyinTokenFilter(tokenizer);
+        while (tokenStream.incrementToken())
+        {
+            CharTermAttribute attribute = tokenizer.getAttribute(CharTermAttribute.class);
+            // 偏移量
+            OffsetAttribute offsetAtt = tokenizer.getAttribute(OffsetAttribute.class);
+            // 距离
+            PositionIncrementAttribute positionAttr = tokenizer.getAttribute(PositionIncrementAttribute.class);
+            // 词性
+            TypeAttribute typeAttr = tokenizer.getAttribute(TypeAttribute.class);
+            System.out.printf("[%d:%d %d] %s/%s\n", offsetAtt.startOffset(), offsetAtt.endOffset(), positionAttr.getPositionIncrement(), attribute, typeAttr.type());
         }
     }
 }


### PR DESCRIPTION
在Lucene中使用拼音搜索时不想添加其他依赖，添加了一个拼音分词过滤器，支持全拼、首字母搜索